### PR TITLE
帖子详情评论 新增高亮楼主的评论的功能

### DIFF
--- a/src/components/chaofan/commentItem.vue
+++ b/src/components/chaofan/commentItem.vue
@@ -99,7 +99,8 @@
                 </div>
             </div>
             <div v-if="item.children&&item.children.length">
-                <commentitem :postInfo="{postOwnerUserId:postInfo.postOwnerUserId}" @rep="rep" @refreshComment="refreshComment" @refreshDelete="refreshDelete" @toReplay2="toReplay2" :showRep="showR" :treeData="item.children"></commentitem>
+                <commentitem :postInfo="{postOwnerUserId:postInfo.postOwnerUserId,isPostOwnerHighlight:postInfo.isPostOwnerHighlight}" 
+                @rep="rep" @refreshComment="refreshComment" @refreshDelete="refreshDelete" @toReplay2="toReplay2" :showRep="showR" :treeData="item.children"></commentitem>
                 <!-- <div  v-for="(item,index) in item.children" :key="index" class="comment_item">
                     <div class="c_left">
                         <img @click.stop="doZanComment(1,item)" src="../../assets/images/icon/up.png" alt="">
@@ -134,7 +135,6 @@ export default {
     data(){
         return {
             
-            isPostOwnerHighlight: true,
             showIcon: false,
             moment: moment,
             replayItem: null,
@@ -201,7 +201,7 @@ export default {
             if(item.forumAdminHighlight){
                 // 版主高亮
                 return 1;
-            }else if(this.isPostOwnerHighlight && this.postInfo.postOwnerUserId == item.userInfo.userId){
+            }else if(this.postInfo.isPostOwnerHighlight && this.postInfo.postOwnerUserId == item.userInfo.userId){
                 // 楼主高亮
                 return 2;                
             }

--- a/src/components/chaofan/commentItem.vue
+++ b/src/components/chaofan/commentItem.vue
@@ -15,7 +15,7 @@
             </div>
         </div>
         <div class="c_content">
-            <div :class="item.forumAdminHighlight?'user_info_highlight':'user_info'">
+            <div :class="getCommentUserinfoClazz(item)">
                 <img :src="imgOrigin+item.userInfo.icon+'?x-oss-process=image/resize,h_40'" alt="">
                 <span  @click.stop="toUser(item.userInfo)" class="username">{{item.userInfo.userName}}</span>
                 <span v-if="item.userInfo.userTag" title="用户在板块的标签" style="font-size:14px; background-color: rgb(237, 239, 241); color: rgb(26, 26, 27); margin-left: 5px ">{{item.userInfo.userTag.data}}</span>
@@ -30,7 +30,7 @@
                 <div v-if="item.forumAdmin&&item.forumAdminHighlight"  @click="unHighlightComment(item)" class="to_delete">取消高亮</div>
                 <div v-if="item.forumAdmin&&!item.forumAdminHighlight"  @click="highlightComment(item)" class="to_delete">设为高亮</div>  
             </div> 
-            <div class="content" :style="item.forumAdminHighlight?'background: #b2e8d1;':''">
+            <div class="content" :style="getCommentContentStyle(item)">
                 <p v-if="!item.atUsers" v-html="islink(item.text)"></p>
                 <p v-if="item.atUsers" @click="clickComment($event)" v-html="doText(item)"></p>
                 <span v-if="item.imageNames" class="comImgs">
@@ -99,7 +99,7 @@
                 </div>
             </div>
             <div v-if="item.children&&item.children.length">
-                <commentitem @rep="rep" @refreshComment="refreshComment" @refreshDelete="refreshDelete" @toReplay2="toReplay2" :showRep="showR" :treeData="item.children"></commentitem>
+                <commentitem :postInfo="{postOwnerUserId:postInfo.postOwnerUserId}" @rep="rep" @refreshComment="refreshComment" @refreshDelete="refreshDelete" @toReplay2="toReplay2" :showRep="showR" :treeData="item.children"></commentitem>
                 <!-- <div  v-for="(item,index) in item.children" :key="index" class="comment_item">
                     <div class="c_left">
                         <img @click.stop="doZanComment(1,item)" src="../../assets/images/icon/up.png" alt="">
@@ -134,6 +134,7 @@ export default {
     data(){
         return {
             
+            isPostOwnerHighlight: true,
             showIcon: false,
             moment: moment,
             replayItem: null,
@@ -195,6 +196,36 @@ export default {
         }
     },
     methods: {
+
+        getHighlightStatus(item){
+            if(item.forumAdminHighlight){
+                // 版主高亮
+                return 1;
+            }else if(this.isPostOwnerHighlight && this.postInfo.postOwnerUserId == item.userInfo.userId){
+                // 楼主高亮
+                return 2;                
+            }
+            return 0;
+
+        },
+        getCommentContentStyle(item){
+            let highlightStatus = this.getHighlightStatus(item);           
+            if(highlightStatus == 1){
+                return 'background: #b2e8d1;';
+            }else if(highlightStatus == 2){
+                return 'background: #BFDFFF;';
+            }
+            return '';
+        },
+        getCommentUserinfoClazz(item){
+            let highlightStatus = this.getHighlightStatus(item);
+            if(highlightStatus == 1){
+                return 'user_info_highlight_1';
+            }else if(highlightStatus == 2){
+                return 'user_info_highlight_2';
+            }
+            return 'user_info';
+        },
         clickComment:function (event) {
             
             if(event.target.nodeName === 'SPAN'){
@@ -602,7 +633,7 @@ export default {
                 }
             }
         }
-        .user_info_highlight{
+        .user_info_highlight_1{
             background: #b2e8d1;
             img{
                 width: 24px;
@@ -627,6 +658,39 @@ export default {
             }
             .zan_shu{
                 color: #111;
+                cursor: pointer;
+                img{
+                    width: 24px;
+                    height: 24px;
+                    margin-right: 4px;
+                }
+            }
+        }
+        .user_info_highlight_2{
+            background: #BFDFFF;
+            img{
+                width: 24px;
+                height: 24px;
+                vertical-align: middle;
+                border-radius: 50%;
+                margin-right: 2px;
+            }
+            .username{
+                color: #1890ff;
+                cursor: pointer;
+                margin-left: 6px;
+                line-height: 24px;
+                &:hover{
+                    text-decoration: underline;
+                }
+            }
+            .time{
+                padding-left: 15px;
+                color: #555;
+                font-size: 12px;
+            }
+            .zan_shu{
+                color: #555;
                 cursor: pointer;
                 img{
                     width: 24px;

--- a/src/views/list/articleDetail.vue
+++ b/src/views/list/articleDetail.vue
@@ -101,7 +101,7 @@
                               {{params.order=='new'?'新评':'热评'}}
                             </div>
                           </div> 
-                          <commentitem :postInfo="{disableComment:pagedata.disableComment,forumAdmin:pagedata.forumAdmin}" @refreshDelete="refreshDelete" @toReplay2="toReplay2" @refreshComment="refreshComment" :treeData="treeData"></commentitem>
+                          <commentitem :postInfo="{disableComment:pagedata.disableComment,forumAdmin:pagedata.forumAdmin,postOwnerUserId:pagedata.userInfo.userId}" @refreshDelete="refreshDelete" @toReplay2="toReplay2" @refreshComment="refreshComment" :treeData="treeData"></commentitem>
                           <div v-if="!lists.length" class="no_comment">
                               还没有评论，你的机会来了 ~
                           </div> 

--- a/src/views/list/articleDetail.vue
+++ b/src/views/list/articleDetail.vue
@@ -101,7 +101,7 @@
                               {{params.order=='new'?'新评':'热评'}}
                             </div>
                             <div class="tright" style="margin-right: 20px;">
-                              <el-checkbox v-model="isPostOwnerCommentHighlight">楼主高亮</el-checkbox>
+                              <el-checkbox v-model="isPostOwnerCommentHighlight">高亮楼主评论</el-checkbox>
                             </div>
                           </div> 
                           <commentitem :postInfo="{disableComment:pagedata.disableComment,forumAdmin:pagedata.forumAdmin, 

--- a/src/views/list/articleDetail.vue
+++ b/src/views/list/articleDetail.vue
@@ -100,7 +100,7 @@
                               <img :src="imgOrigin+ 'biz/20712d8583a287b4941d8852af4f15e5.png'" alt="">
                               {{params.order=='new'?'新评':'热评'}}
                             </div>
-                            <div class="tright">
+                            <div class="tright" style="margin-right: 20px;">
                               <el-checkbox v-model="isPostOwnerCommentHighlight">楼主高亮</el-checkbox>
                             </div>
                           </div> 
@@ -1361,12 +1361,21 @@ queryChildren (parent, list) {
   padding: 2px 4px;
   cursor: pointer;
   &:hover{
-    background: #ddd;
-    
+    background: #ddd;    
   }
   img{
     vertical-align: middle;
     width: 16px;
   }
 }
+
+/deep/.el-checkbox {
+  .el-checkbox__input{
+    margin-bottom:-2px;
+  }
+  .el-checkbox__label{
+    margin-left:-8px;
+  }
+}
+
 </style>

--- a/src/views/list/articleDetail.vue
+++ b/src/views/list/articleDetail.vue
@@ -100,8 +100,13 @@
                               <img :src="imgOrigin+ 'biz/20712d8583a287b4941d8852af4f15e5.png'" alt="">
                               {{params.order=='new'?'新评':'热评'}}
                             </div>
+                            <div class="tright">
+                              <el-checkbox v-model="isPostOwnerCommentHighlight">楼主高亮</el-checkbox>
+                            </div>
                           </div> 
-                          <commentitem :postInfo="{disableComment:pagedata.disableComment,forumAdmin:pagedata.forumAdmin,postOwnerUserId:pagedata.userInfo.userId}" @refreshDelete="refreshDelete" @toReplay2="toReplay2" @refreshComment="refreshComment" :treeData="treeData"></commentitem>
+                          <commentitem :postInfo="{disableComment:pagedata.disableComment,forumAdmin:pagedata.forumAdmin, 
+                          postOwnerUserId:pagedata.userInfo.userId,isPostOwnerHighlight:isPostOwnerCommentHighlight}" 
+                          @refreshDelete="refreshDelete" @toReplay2="toReplay2" @refreshComment="refreshComment" :treeData="treeData"></commentitem>
                           <div v-if="!lists.length" class="no_comment">
                               还没有评论，你的机会来了 ~
                           </div> 
@@ -208,6 +213,7 @@ export default {
   data() {
     return {
       
+      isPostOwnerCommentHighlight: false,
       hasData: true,
       currentRole: 'adminDashboard',
       count: 5,


### PR DESCRIPTION
类似于百度贴吧的“只看楼主”功能，这里只是修改了楼主评论的背景色。

默认不高亮。
评论如有版主高亮，优先版主高亮。

个人感觉在网络迷踪板块，题主的评论有时候带有提示等信息，看起来更方便些。或者在以后帖子里看小说等也有帮助。
站长看下有必要没。

对比图如下：
![对比图1](https://i.chao.fun/biz/a72e30ea92c149fea9450028584b7cf5.png)
![对比图2](https://i.chao.fun/biz/63216ed7062c74b12dfdf7d9be72bbc6.png)
