### PR TITLE
20220108_新增保持 “高亮楼主评论” 的状态&修复bug

### DIFF
--- a/src/layout/components/Navbar.vue
+++ b/src/layout/components/Navbar.vue
@@ -69,7 +69,7 @@
                 <p>未登录</p>
               </div>
         </div>
-        <el-dropdown-menu slot="dropdown">
+        <el-dropdown-menu v-if="islogin" slot="dropdown">
           <router-link v-if="islogin" to="/my">
             <el-dropdown-item>我的</el-dropdown-item>
           </router-link>

--- a/src/views/list/articleDetail.vue
+++ b/src/views/list/articleDetail.vue
@@ -101,7 +101,7 @@
                               {{params.order=='new'?'新评':'热评'}}
                             </div>
                             <div class="tright" style="margin-right: 20px;">
-                              <el-checkbox v-model="isPostOwnerCommentHighlight" @change="postOwnerCommentHighlightCheckboxChange">高亮楼主评论</el-checkbox>
+                              <el-checkbox v-model="isPostOwnerCommentHighlight" @change="postOwnerCommentHighlightCheckboxChange" title="在“设置”中可设置为默认选中">高亮楼主评论</el-checkbox>
                             </div>
                           </div> 
                           <commentitem :postInfo="{disableComment:pagedata.disableComment,forumAdmin:pagedata.forumAdmin, 

--- a/src/views/list/articleDetail.vue
+++ b/src/views/list/articleDetail.vue
@@ -1382,8 +1382,9 @@ queryChildren (parent, list) {
 }
 
 /deep/.el-checkbox {
-  .el-checkbox__input{
+  .el-checkbox__input{    
     margin-bottom:-2px;
+    z-index: 0;
   }
   .el-checkbox__label{
     margin-left:-8px;

--- a/src/views/list/articleDetail.vue
+++ b/src/views/list/articleDetail.vue
@@ -101,7 +101,7 @@
                               {{params.order=='new'?'新评':'热评'}}
                             </div>
                             <div class="tright" style="margin-right: 20px;">
-                              <el-checkbox v-model="isPostOwnerCommentHighlight">高亮楼主评论</el-checkbox>
+                              <el-checkbox v-model="isPostOwnerCommentHighlight" @change="postOwnerCommentHighlightCheckboxChange">高亮楼主评论</el-checkbox>
                             </div>
                           </div> 
                           <commentitem :postInfo="{disableComment:pagedata.disableComment,forumAdmin:pagedata.forumAdmin, 
@@ -277,6 +277,11 @@ export default {
     ...mapState(['var'])
   },
   mounted(){
+
+    if("true" == localStorage.getItem("chao.fun.localSetting.isStoragePostOwnerCommentHighlight")){
+        this.isPostOwnerCommentHighlight = ("true" == localStorage.getItem("chao.fun.localSetting.isPostOwnerCommentHighlight"));
+    }
+
     if(document.body.clientWidth<700){
       this.isPhone = true
     }
@@ -304,6 +309,13 @@ export default {
     this.inputBlur()
   },
   methods:{
+
+    postOwnerCommentHighlightCheckboxChange(val){
+      if("true" == localStorage.getItem("chao.fun.localSetting.isStoragePostOwnerCommentHighlight")){
+        localStorage.setItem("chao.fun.localSetting.isPostOwnerCommentHighlight",val);
+      }      
+    },
+
     checkoutOrder(){
       if(this.params.order=='new'){
         this.params.order= 'hot'

--- a/src/views/list/setting.vue
+++ b/src/views/list/setting.vue
@@ -44,6 +44,10 @@
                   <span @click="toBindPhone" style="color:#409eff;text-decoration:underline;cursor:pointer;">去绑定</span>
                 </div>
               </div>
+              <div class="title">本地设置</div>
+              <div>
+                <el-checkbox v-model="isStoragePostOwnerCommentHighlight" @change="storagePostOwnerCommentHighlightCheckboxChange">保持高亮楼主评论设置</el-checkbox>
+              </div>
             </div>
             </div>
         </div>
@@ -81,6 +85,8 @@ export default {
   // components: { adminDashboard, editorDashboard },
   data() {
     return {
+
+      isStoragePostOwnerCommentHighlight: false,
       type: '',
       title: '',
       time: '',
@@ -118,6 +124,9 @@ export default {
     }
   },
   mounted(){
+    this.isStoragePostOwnerCommentHighlight = ("true" == localStorage.getItem("chao.fun.localsetting.isStoragePostOwnerCommentHighlight"));    
+    localStorage.setItem("chao.fun.localsetting.isStoragePostOwnerCommentHighlight",this.isStoragePostOwnerCommentHighlight);
+
     if(document.body.clientWidth<700){
       this.isPhone = true
     }
@@ -133,6 +142,11 @@ export default {
     // this.filedata.url = this.imgOrigin+this.$store.state.user.userInfo.icon;
   },
   methods:{
+
+    storagePostOwnerCommentHighlightCheckboxChange(val){
+      localStorage.setItem("chao.fun.localsetting.isStoragePostOwnerCommentHighlight",val);
+    },
+
     toSendCode(){
       
       if(!this.time){
@@ -358,6 +372,13 @@ export default {
         cursor: pointer;
       }
     }
+  }
+}
+
+/deep/.el-checkbox {  
+  .el-checkbox__label{
+    margin-left:-5px;
+    font-size: 14px;
   }
 }
 </style>

--- a/src/views/list/setting.vue
+++ b/src/views/list/setting.vue
@@ -124,8 +124,8 @@ export default {
     }
   },
   mounted(){
-    this.isStoragePostOwnerCommentHighlight = ("true" == localStorage.getItem("chao.fun.localsetting.isStoragePostOwnerCommentHighlight"));    
-    localStorage.setItem("chao.fun.localsetting.isStoragePostOwnerCommentHighlight",this.isStoragePostOwnerCommentHighlight);
+    this.isStoragePostOwnerCommentHighlight = ("true" == localStorage.getItem("chao.fun.localSetting.isStoragePostOwnerCommentHighlight"));    
+    localStorage.setItem("chao.fun.localSetting.isStoragePostOwnerCommentHighlight",this.isStoragePostOwnerCommentHighlight);
 
     if(document.body.clientWidth<700){
       this.isPhone = true
@@ -144,7 +144,8 @@ export default {
   methods:{
 
     storagePostOwnerCommentHighlightCheckboxChange(val){
-      localStorage.setItem("chao.fun.localsetting.isStoragePostOwnerCommentHighlight",val);
+      localStorage.setItem("chao.fun.localSetting.isStoragePostOwnerCommentHighlight",val);
+      this.$toast("设置成功！");  
     },
 
     toSendCode(){

--- a/src/views/list/setting.vue
+++ b/src/views/list/setting.vue
@@ -46,7 +46,7 @@
               </div>
               <div class="title">本地设置</div>
               <div>
-                <el-checkbox v-model="isStoragePostOwnerCommentHighlight" @change="storagePostOwnerCommentHighlightCheckboxChange">保持高亮楼主评论设置</el-checkbox>
+                <el-checkbox v-model="isStoragePostOwnerCommentHighlight" @change="storagePostOwnerCommentHighlightCheckboxChange">保持高亮楼主评论状态</el-checkbox>
               </div>
             </div>
             </div>

--- a/src/views/list/setting.vue
+++ b/src/views/list/setting.vue
@@ -394,7 +394,10 @@ export default {
   }
 }
 
-/deep/.el-checkbox {  
+/deep/.el-checkbox {
+  .el-checkbox__input{
+    z-index: 0;
+  }
   .el-checkbox__label{
     margin-left:-5px;
     font-size: 14px;

--- a/src/views/list/setting.vue
+++ b/src/views/list/setting.vue
@@ -45,8 +45,19 @@
                 </div>
               </div>
               <div class="title">本地设置</div>
-              <div>
-                <el-checkbox v-model="isStoragePostOwnerCommentHighlight" @change="storagePostOwnerCommentHighlightCheckboxChange">保持高亮楼主评论状态</el-checkbox>
+              <div style="display: flex;">
+                <div>
+                  <el-checkbox v-model="isStoragePostOwnerCommentHighlight"
+                    @change="storagePostOwnerCommentHighlightCheckboxChange">保持 “高亮楼主评论” 的状态</el-checkbox>
+                </div>
+                <div class="checkboxTooltip">
+                  <el-tooltip placement="right">
+                    <div slot="content">未选中时：<br />不同帖子的 “高亮楼主评论” 的状态是独立的，<br />即每次打开帖子默认为不选中 “高亮楼主评论”<br /><br />
+                      选中时：<br />不同帖子将同步“高亮楼主评论”的状态<br />即：本帖子设置为选中，下次打开其它帖子也为选中</div>
+                    <img :src="imgOrigin+ 'biz/2217ebcccf05a1281f70582c2ad6a191.png?x-oss-process=image/resize,h_20'"
+                      alt="">
+                  </el-tooltip>
+                </div>
               </div>
             </div>
             </div>
@@ -373,6 +384,13 @@ export default {
         cursor: pointer;
       }
     }
+  }
+}
+.checkboxTooltip{
+  margin-left: 10px;
+  img{
+    width: 20px;
+    height: 20px;
   }
 }
 


### PR DESCRIPTION
## 0. 新增保持 “高亮楼主评论” 的状态
**该设置会保存在本地浏览器，未同步至服务器保存。** *更换浏览器需要重新设置该项*


在设置中：
![image](https://user-images.githubusercontent.com/97150762/148648655-e38ed16f-efc9-43d2-92f6-479f708f264c.png)
在帖子中：
![image](https://user-images.githubusercontent.com/97150762/148648697-e88baaf4-4085-40c2-b56e-d60132e007bf.png)


## 1. fix：未登录状态，点击右上角时，会显示“消息”选项的bug
![image](https://user-images.githubusercontent.com/97150762/148648568-2f49ac4e-aa48-4768-971e-ab946fd91cc3.png)

## 2. fix：el-checkbox组件的显示问题
![image](https://user-images.githubusercontent.com/97150762/148648609-4220b6c4-72c6-4990-a573-b429b02da44f.png)


