### PR TITLE
issues #198 帖子详情404页面的移动端适配

### DIFF
--- a/src/views/list/articleDetail.vue
+++ b/src/views/list/articleDetail.vue
@@ -1256,6 +1256,9 @@ queryChildren (parent, list) {
     font-size: 44px;
     
     color: cornflowerblue;
+    img{
+      width: 100%;
+    }
   }
   p{
     text-align: center;


### PR DESCRIPTION
issues #198 帖子详情404页面的移动端适配

效果图如下：
![image](https://user-images.githubusercontent.com/97150762/149000641-cc309534-b1a0-4878-9960-8552eb4171d6.png)
