### PR TITLE
修复issue-251，搜索关闭帖子后没有保留offset

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -202,6 +202,7 @@ export const constantRoutes = [
         path: '/search',
         name: 'search',
         component: () => import('@/views/list/search'),
+        props: route => ({ q: route.query.q }),
         meta: { title: '',keepAlive: true,},
         hidden: true
       },

--- a/src/views/list/search.vue
+++ b/src/views/list/search.vue
@@ -146,6 +146,7 @@ import attentionItem from "@/components/chaofan/attentionItem.vue";
 export default {
   name: "Dashboard",
   // components: { adminDashboard, editorDashboard },
+  props:['q'],
   data() {
     return {
       hasContent: true,
@@ -185,8 +186,8 @@ export default {
     attentionItem,
   },
   watch: {
-    "$route.query.q"(v) {
-      
+    q(v) {
+      this.scrollTop = 0;
       this.lists = [];
       this.keyword = v;
       this.params.keyword = v;
@@ -330,6 +331,10 @@ export default {
           this.getLists();
         }
     },
+  },
+  activated() {
+    // 重设滚动条位置
+    this.toPosition();
   },
 };
 </script>


### PR DESCRIPTION
这个问题分开看：
1，搜索结果组件search.vue虽然keep-alive，在关闭帖子时时仍然会再次请求搜索结果。
2，issue中观测到的offset问题。
针对1，将侦听对象$route.query.q改为prop属性q，q在路由定义处绑定，能实现在切换路由时不会触发再次发送搜索请求。
针对2，侦听scroll事件记录offset，在组件重新渲染时重设。