### PR TITLE
优化首页没看过和搜索一列（issue-252）

### DIFF
--- a/src/components/chaofan/common/selectList.vue
+++ b/src/components/chaofan/common/selectList.vue
@@ -58,6 +58,17 @@
       <div @click="checkoutOk" :class="['c_nav_item_t',params.onlyNew?'oks':'']">
           没看过
       </div>
+      <div class="search_icon">
+        <i class="el-icon-search"></i>
+        <el-input
+          class="search_input"
+          placeholder="搜索"
+          prefix-icon="el-icon-search"
+          @change="toSearch(keyword)"
+          v-model="keyword"
+        >
+        </el-input>
+      </div>
     </div>
         
         
@@ -120,6 +131,7 @@
             value: 'all'
           },
         ],
+        keyword: ''
      }
    },
    
@@ -138,7 +150,7 @@
      
    },
    mounted() {
-    
+    this.keyword = this.$route.query.q;
    },
    methods: {
     doRange(){
@@ -200,7 +212,23 @@
 .phones{
   height: 34px;
   text-align: left;
-  // margin-bottom: ;
+  margin: 10px;
+  .search_icon {
+    flex: auto;
+    font-size: 24px;
+    // margin-right: 10px;
+    position: relative;
+    z-index: 1;
+    width: 100px;
+    /*margin-left: 40px;*/
+
+    .search_input {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      right: 0;
+    }
+  }
 }
 .mode_icon{
   width: 26px;

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -27,17 +27,6 @@
             >
               <i class="el-icon-refresh"></i>
             </div>
-            <div v-if="ISPHONE" class="search_icon">
-              <i class="el-icon-search"></i>
-              <el-input
-                class="search_input"
-                placeholder="搜索"
-                prefix-icon="el-icon-search"
-                @change="toSearch(keyword)"
-                v-model="keyword"
-              >
-              </el-input>
-            </div>
           </div>
           <div
             class="grid-content"
@@ -178,7 +167,6 @@ export default {
       isPhone: false,
       ifcanget: true,
       loadAll: false,
-      keyword: "",
       isRecommend: false,
       forumInfo: null,
     };
@@ -237,7 +225,6 @@ export default {
     }else{
       this.params.pageSize = 30
     }
-    this.keyword = this.$route.query.q;
     this.toPosition();
     // console.log('scrollHeight',this.scrollHeight)
     let self = this;
@@ -521,23 +508,6 @@ export default {
     &:hover {
       color: $linkcolor;
     }
-  }
-}
-
-.search_icon {
-  line-height: 56px;
-  font-size: 24px;
-  margin-right: 10px;
-  position: relative;
-  z-index: 1;
-  width: 100px;
-  /*margin-left: 40px;*/
-
-  .search_input {
-    position: absolute;
-    top: 0;
-    width: 100%;
-    right: 0;
   }
 }
 


### PR DESCRIPTION
issuse #252 
### 将首页的搜索框从dashboard/index.vue挪到selectList.vue，以实现样式的统一和谐。
#### 修改前
![image](https://user-images.githubusercontent.com/13654706/155437768-9ff5859f-22ce-4136-b1de-dff6e7e90f3f.png)

### 修改后
![image](https://user-images.githubusercontent.com/13654706/155437602-68938845-cd10-4144-aea8-36536e7419bc.png)
![image](https://user-images.githubusercontent.com/13654706/155437817-c0d69730-bd8a-415f-9b23-8a3274208618.png)
![image](https://user-images.githubusercontent.com/13654706/155437878-3e4e15a0-af8e-4271-a755-14934fdae501.png)
