### PR TITLE
修复板块排名中的标题问题

### DIFF
--- a/src/views/activity/forumRank.vue
+++ b/src/views/activity/forumRank.vue
@@ -43,7 +43,7 @@ export default {
   },
   mounted(){
     this.getForumTopUps()
-    document.title = "24 小时用户排名";
+    document.title = "24 小时板块排名";
   },
   methods:{
     getForumTopUps(){

--- a/src/views/chaofun-webview/activity/forumRank.vue
+++ b/src/views/chaofun-webview/activity/forumRank.vue
@@ -43,7 +43,7 @@ export default {
   },
   mounted(){
     this.getForumTopUps()
-    document.title = "24 小时用户排名";
+    document.title = "24 小时板块排名";
   },
   methods:{
     getForumTopUps(){


### PR DESCRIPTION
将‘用户排名’修正为‘板块排名’