### PR TITLE
feat:消息列表调整

### DIFF
--- a/src/components/chaofan/commentItem.vue
+++ b/src/components/chaofan/commentItem.vue
@@ -1,6 +1,6 @@
 <template>
  <div>
-     <div v-for="(item,index) in treeData" :key="index" class="comment_item">
+     <div v-for="(item,index) in treeData" :key="index" :id="'commentItem_'+item.id" class="comment_item">
         <div :class="['c_left',{'c_left2':ISPHONE}]">
             <div class="lay">
                 <img v-if="item.vote != 1" @click.stop="doZanComment(1, item)" src="../../assets/images/icon/up.png" alt="" />
@@ -234,7 +234,10 @@ export default {
         },
 
         getHighlightStatus(item){
-            if(item.forumAdminHighlight){
+            if(item.isJumpHighlight){
+              // 跳转高亮
+              return 3;
+            }else if(item.forumAdminHighlight){
                 // 版主高亮
                 return 1;
             }else if(this.postInfo.isPostOwnerHighlight && this.postInfo.postOwnerUserId == item.userInfo.userId){
@@ -246,7 +249,9 @@ export default {
         },
         getCommentContentStyle(item){
             let highlightStatus = this.getHighlightStatus(item);
-            if(highlightStatus == 1){
+            if(highlightStatus == 3){
+              return 'background: #FFE1F1;';
+            }else if(highlightStatus == 1){
                 return 'background: #b2e8d1;';
             }else if(highlightStatus == 2){
                 return 'background: #BFDFFF;';
@@ -255,7 +260,9 @@ export default {
         },
         getCommentUserinfoClazz(item){
             let highlightStatus = this.getHighlightStatus(item);
-            if(highlightStatus == 1){
+            if(highlightStatus == 3){
+                return 'user_info_highlight_3';
+            }else if(highlightStatus == 1){
                 return 'user_info_highlight_1';
             }else if(highlightStatus == 2){
                 return 'user_info_highlight_2';
@@ -737,6 +744,39 @@ export default {
                     margin-right: 4px;
                 }
             }
+        }
+        .user_info_highlight_3{
+          background: #FFE1F1;
+          img{
+            width: 24px;
+            height: 24px;
+            vertical-align: middle;
+            border-radius: 50%;
+            margin-right: 2px;
+          }
+          .username{
+            color: #1890ff;
+            cursor: pointer;
+            margin-left: 6px;
+            line-height: 24px;
+            &:hover{
+              text-decoration: underline;
+            }
+          }
+          .time{
+            padding-left: 15px;
+            color: #555;
+            font-size: 12px;
+          }
+          .zan_shu{
+            color: #555;
+            cursor: pointer;
+            img{
+              width: 24px;
+              height: 24px;
+              margin-right: 4px;
+            }
+          }
         }
         .content{
             font-size: 15px;

--- a/src/components/chaofan/noticeItem.vue
+++ b/src/components/chaofan/noticeItem.vue
@@ -2,19 +2,22 @@
  <div>
      <div style="text-align: right;float:right;color: #bbb;height: 0px;cursor: pointer;position: relative;top: 15px;right: 5px;" @click="humanizeTimeFormatSwitch"
           title="点击切换时间格式">
-       <span v-if="humanizeTimeFormat">{{ moment.duration(moment(items.gmtCreate) - moment()).humanize(true) }}</span>
+       <span v-if="humanizeTimeFormat0">{{ moment.duration(moment(items.gmtCreate) - moment()).humanize(true) }}</span>
        <span v-else>{{ moment(items.gmtCreate).format('YYYY年MM月DD日 HH:mm:ss') }}</span>
      </div>
 
+     <!-- 点赞帖子 -->
      <div v-if="items.type=='upvote_post'" class="zan">
          <div class="item">
              <!-- <span class="tab">&lt;点赞&gt;</span> -->
             <span v-if="items.sender" @click.stop="toUser(items.sender)" class="username user_name">【{{items.sender.userName}}】</span>
             <span v-if="!items.sender">未登录访客</span>
-            <span>点赞了你的</span>
+            <span>点赞了你的帖子</span>
             <span @click="toDetail(items)" class="tiezi_title">【{{items.post.title.length>15?items.post.title.slice(0,15)+'...':items.post.title}}】</span>
         </div>
      </div>
+
+     <!-- 点赞评论 -->
      <div v-if="items.type=='upvote_comment'" class="zan">
          <div class="item">
             <span v-if="items.sender" @click.stop="toUser(items.sender)" class="username user_name">【{{items.sender.userName}}】</span>
@@ -23,48 +26,60 @@
             <span @click="toDetail(items)" class="tiezi_title">【{{items.post.title.length>15?items.post.title.slice(0,15)+'...':items.post.title}}】</span>
             <span>下的评论</span>
          </div>
+         <div class="comment" @click="toDetailComment(items.post.postId,items.comment.id)">
+           <span></span>你说：{{items.comment.text}} <noticeItemImages :imageNames="items.comment.imageNames" /><span></span>
+         </div>
      </div>
-     <!-- {{items.type}} -->
+
+     <!-- 评论帖子 -->
      <div v-if="items.type=='comment_post'" class="pinlun">
          <div class="item">
             <span v-if="items.sender" @click.stop="toUser(items.sender)" class="username user_name">【{{items.sender.userName}}】</span>
             <span v-if="!items.sender">未登录访客</span>
-            <span>评论了你的</span>
+            <span>评论了你的帖子</span>
             <span @click="toDetail(items)" class="tiezi_title">【{{items.post.title.length>15?items.post.title.slice(0,15)+'...':items.post.title}}】</span>
          </div>
-         <div class="comment">
+         <div class="comment" @click="toDetailComment(items.post.postId,items.comment.id)">
              <!-- <img :src="imgOrigin+items.sender.icon+'?x-oss-process=image/resize,h_80/format,webp/quality,q_75'" alt=""> -->
-             <span></span>评论说： {{items.comment.text}}<span></span>
+             <span></span>他评论说： {{items.comment.text}} <noticeItemImages :imageNames="items.comment.imageNames" /><span></span>
          </div>
      </div>
+
+     <!-- 回评 -->
      <div v-if="items.type=='sub_comment'" class="pinlun">
          <div class="item">
             <span v-if="items.sender" @click.stop="toUser(items.sender)" class="username user_name">【{{items.sender.userName}}】</span>
             <span v-if="!items.sender">未登录访客</span>
             <span>在</span>
             <span @click="toDetail(items)" class="tiezi_title">【{{items.post.title.length>15?items.post.title.slice(0,15)+'...':items.post.title}}】</span>
+            <span>回复了你</span>
          </div>
-         <div class="comment">
-             <!-- <span></span>评论说： {{items.comment.text}}<span></span> -->
+         <div class="comment" style="background: #eee;color: #999;" @click="toDetailComment(items.post.postId,items.parentComment.id)">
+           <span></span>你说：{{items.parentComment.text}} <noticeItemImages :imageNames="items.parentComment.imageNames" /><span></span>
+         </div>
+         <div class="comment" style="margin-left: 20px;" @click="toDetailComment(items.post.postId,items.comment.id)">
              <span>
-                 回复了评论：{{items.comment.text}} 
-                 <!-- {{items.comment.userInfo.userName}} @ {{items.parentComment.userInfo.userName}} ：{{items.comment.text}} -->
+                 他回复说：{{items.comment.text}} <noticeItemImages :imageNames="items.comment.imageNames" />
              </span>
          </div>
      </div>
+
+     <!-- @我 -->
      <div v-if="items.type=='at'" class="pinlun">
          <div class="item">
             <span v-if="items.sender" @click.stop="toUser(items.sender)" class="username user_name">【{{items.sender.userName}}】</span>
             <span v-if="!items.sender">未登录访客</span>
             在
             <span @click="toDetail(items)" class="tiezi_title">【{{items.post.title.length>15?items.post.title.slice(0,15)+'...':items.post.title}}】</span>
-            <span>在评论区：</span>
+            <span>的评论区：</span>
          </div>
-         <div class="comment">
+         <div class="comment" @click="toDetailComment(items.post.postId,items.comment.id)">
              <!-- <img :src="imgOrigin+items.sender.icon+'?x-oss-process=image/resize,h_80/format,webp/quality,q_75'" alt=""> -->
-             <span></span>@你说： {{items.comment.text}}<span></span>
+             <span></span>@你说： {{items.comment.text}} <noticeItemImages :imageNames="items.comment.imageNames" /><span></span>
          </div>
      </div>
+
+     <!-- 被删帖 -->
      <div v-if="items.type=='delete_post'" class="zan">
        <div class="item">
          <span>你的帖子 </span>
@@ -74,6 +89,8 @@
          <span v-if="!items.reason">请阅读炒饭和分区发帖规范。</span>
        </div>
      </div>
+
+     <!-- 通知消息 -->
      <div v-if="items.type=='text_notice'" class="zan">
        <div>
          {{ items.title }}
@@ -82,12 +99,14 @@
          <span style="font-weight: bold;">{{ items.text }}</span>
        </div>
      </div>
+
  </div>
 </template>
 
 <script>
 import 'moment/locale/zh-cn'
 import moment from 'moment'
+import noticeItemImages from "_c/chaofan/noticeItemImages";
  export default {
    name: '',
    data(){
@@ -102,7 +121,7 @@ import moment from 'moment'
                return {}
            }
        },
-       humanizeTimeFormat: {
+       humanizeTimeFormat0: {
          type: Boolean,
          default() {
            return true;
@@ -110,7 +129,7 @@ import moment from 'moment'
        },
    },
    components: {
-
+     noticeItemImages,
    },
    created() {
    },
@@ -148,6 +167,13 @@ import moment from 'moment'
             });
             window.open(routeData.href, '_blank');
         },
+       toDetailComment(postId,commentId){
+         let routeData = this.$router.resolve({
+           name: "articleDetail",
+           params: {postId: postId},
+         });
+         window.open(routeData.href+"?commentId="+commentId, '_blank');
+       },
        pastePasswordAndUrl(password) {
          let str = "红包口令：" + password + "    " + "红包链接：https://chao.fun/webview/fbi/redPacket?password=" + password;
          this.copy(str);
@@ -171,7 +197,7 @@ import moment from 'moment'
 .item{
     background: #fff;
     
-    // border-bottom: 1px solid #f1f1f1;
+    // border-bottom: 1px solid #f6f6f6;
     width: 100%;
 
     span{
@@ -186,7 +212,7 @@ import moment from 'moment'
     overflow: hidden;
 }
 .pinlun{
-    // border-bottom: 1px solid #f1f1f1;
+    // border-bottom: 1px solid #f6f6f6;
     padding-bottom: 10px;
     .item{
         border-bottom: none;
@@ -197,8 +223,10 @@ import moment from 'moment'
     margin-left: 10px;
     margin-right: 10px;
     margin-top: 6px;
-    border: 1px solid #f1f1f1;
-    background: #f1f1f1;
+    border: 1px solid #f6f6f6;
+    border-radius: 3px;
+    background: #f6f6f6;
+    cursor: pointer;
 }
  .user_name,.tiezi_title{
      font-weight: normal;

--- a/src/components/chaofan/noticeItemImages.vue
+++ b/src/components/chaofan/noticeItemImages.vue
@@ -1,0 +1,42 @@
+<template>
+  <span v-if="imageNames">
+    <span v-for="(image,index) in imageArray" :key="index">
+      <el-popover placement="bottom" trigger="hover" width="324">
+        <viewer :images="[image]">
+          <img :data-source="image" :src="image+ '?x-oss-process=image/resize,w_300/format,webp/quality,q_75'"
+               alt="" style="width: 300px;max-height: 80vh;"/>
+        </viewer>
+        <span slot="reference" style="color: #007bff;cursor: pointer;margin: 0px 3px;">[图片]</span>
+      </el-popover>
+    </span>
+  </span>
+</template>
+
+<script>
+export default {
+  name: "noticeItemImages",
+  props: {
+    imageNames: {
+      type: String,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      imageArray: [],
+    }
+  },
+  created() {
+    if (this.imageNames) {
+      const imageArray = this.imageNames.split(",");
+      imageArray.forEach(image => {
+        this.imageArray.push(this.imgOrigin + image);
+      });
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/views/users/message.vue
+++ b/src/views/users/message.vue
@@ -35,7 +35,7 @@
                   v-for="(item, index) in message"
                   :key="index"
                   :items="item"
-                  :humanizeTimeFormat="humanizeTimeFormat"
+                  :humanizeTimeFormat0="humanizeTimeFormat"
                   @call-father-humanizeTimeFormatSwitch="humanizeTimeFormatSwitch"
                 ></noticeItem>
                 <load-text


### PR DESCRIPTION
# 效果图
## 消息列表
![image](https://user-images.githubusercontent.com/97150762/162926281-baf36060-7e71-44f2-8ef6-8aae7b9c1604.png)
## 帖子详情
![image](https://user-images.githubusercontent.com/97150762/162926798-b5c85c6f-2b4c-4d13-9dc0-df875d1df913.png)

# 修改内容
- 点赞评论显示被点赞内容
- 回复评论显示原评论内容
- 评论内容带有图片时显示图片，可鼠标hover查看。点击hover可查看大图
- 可在消息列表点击评论跳转到帖子，且帖子滚动至评论处并高亮
（url格式：`%BASE_URL%`/p/`{{postId}}`?commentId=`{{commentId}}`）
- 修复了一些原有的bug
