### PR TITLE
修复点大的空白区域无法触发编辑 fix: #312

### DIFF
--- a/src/components/Submit/Editor.vue
+++ b/src/components/Submit/Editor.vue
@@ -161,6 +161,7 @@ export default {
     position: relative;
     bottom: 0px;
     top: 0px;
+    min-height: 300px;
   }
 }
 .toastui-editor-popup-body {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43069149/170255221-de144c47-f31e-49ef-8091-81fbcc3d4e47.png)

height: inherit 无法继承父元素的 min-height